### PR TITLE
Change order of predicted and gold_standard

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: casimir
 Title: Comparing Automated Subject Indexing Methods in R
-Version: 0.3.0
+Version: 0.3.1
 Authors@R: c(
     person("Maximilian", "Kähler", , "m.kaehler@dnb.de", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-4695-0565")),

--- a/R/compute_pr_auc.r
+++ b/R/compute_pr_auc.r
@@ -49,9 +49,9 @@
 #'   "C", "e", 0.2, 1
 #' )
 #'
-#' auc <- compute_pr_auc(gold, pred, mode = "doc-avg")
+#' auc <- compute_pr_auc(pred, gold, mode = "doc-avg")
 compute_pr_auc <- function(
-    gold_standard, predicted,
+    predicted, gold_standard,
     doc_groups = NULL,
     label_groups = NULL,
     mode = "doc-avg",
@@ -99,8 +99,8 @@ compute_pr_auc <- function(
     }
 
     pr_curve <- compute_pr_curve(
-      gold_standard = gold_standard,
       predicted = predicted,
+      gold_standard = gold_standard,
       doc_groups = doc_groups,
       label_groups = label_groups,
       mode = mode,
@@ -133,7 +133,8 @@ compute_pr_auc <- function(
     grouping_var <- set_grouping_var(mode, doc_groups, label_groups)
 
     base_compare <- create_comparison(
-      gold_standard, predicted,
+      predicted = predicted,
+      gold_standard = gold_standard,
       doc_groups = doc_groups,
       label_groups = label_groups,
       graded_relevance = graded_relevance,

--- a/R/compute_pr_curve.r
+++ b/R/compute_pr_curve.r
@@ -61,8 +61,8 @@
 #' )
 #'
 #' pr_curve <- compute_pr_curve(
-#'   gold,
 #'   pred,
+#'   gold,
 #'   mode = "doc-avg",
 #'   optimize_cutoff = TRUE
 #' )
@@ -89,7 +89,7 @@
 #'   geom_path() +
 #'   coord_cartesian(xlim = c(0, 1), ylim = c(0, 1))
 compute_pr_curve <- function(
-    gold_standard, predicted,
+    predicted, gold_standard,
     doc_groups = NULL,
     label_groups = NULL,
     mode = "doc-avg",
@@ -118,7 +118,8 @@ compute_pr_curve <- function(
   }
 
   base_compare <- create_comparison(
-    gold_standard, predicted,
+    predicted = predicted,
+    gold_standard = gold_standard,
     doc_groups = doc_groups,
     label_groups = label_groups,
     graded_relevance = graded_relevance,

--- a/R/compute_ranked_retrieval_scores.r
+++ b/R/compute_ranked_retrieval_scores.r
@@ -45,20 +45,22 @@
 #' )
 #'
 #' results <- compute_ranked_retrieval_scores(
-#'   gold,
-#'   pred
+#'   pred,
+#'   gold
 #' )
 #'
 compute_ranked_retrieval_scores <- function( # nolint styler: off
-    gold_standard,
     predicted,
+    gold_standard,
     doc_groups = NULL,
     drop_empty_groups = options::opt("drop_empty_groups"),
     progress = options::opt("progress")) {
   stopifnot(all(c("label_id", "doc_id") %in% colnames(gold_standard)))
   stopifnot(all(c("label_id", "doc_id", "score") %in% colnames(predicted)))
 
-  gold_vs_pred <- create_comparison(gold_standard, predicted,
+  gold_vs_pred <- create_comparison(
+    predicted = predicted,
+    gold_standard = gold_standard,
     doc_groups = doc_groups
   )
 

--- a/R/compute_set_retrieval_scores.r
+++ b/R/compute_set_retrieval_scores.r
@@ -1,9 +1,9 @@
 #' Compute multi label metrics for subject indexing results
 #'
-#' @param gold_standard expects \code{data.frame} with cols
-#'   \emph{"label_id", "doc_id"}
 #' @param predicted multi-label prediction results. expects \code{data.frame}
 #'   with cols \emph{"label_id", "doc_id"}
+#' @param gold_standard expects \code{data.frame} with cols
+#'   \emph{"label_id", "doc_id"}
 #' @param k integer limit on number of predictions per document to consider.
 #'   Only works when column \emph{"score"} is present in predicted
 #' @param mode aggregation mode: \emph{"doc-avg", "subj-avg", "micro"}
@@ -95,7 +95,7 @@
 #' plan(sequential) # or whatever resources you have
 #'
 #' a <- compute_set_retrieval_scores(
-#'   gold, pred,
+#'   pred, gold,
 #'   mode = "doc-avg",
 #'   compute_bootstrap_ci = TRUE,
 #'   n_bt = 100L
@@ -119,14 +119,14 @@
 #' )
 #'
 #' b <- compute_set_retrieval_scores(
-#'   gold, pred_w_relevance,
+#'   pred_w_relevance, gold,
 #'   mode = "doc-avg",
 #'   graded_relevance = TRUE
 #' )
 #'
 compute_set_retrieval_scores <- function(
-    gold_standard,
     predicted,
+    gold_standard,
     k = NULL,
     mode = "doc-avg",
     compute_bootstrap_ci = FALSE,
@@ -157,7 +157,8 @@ compute_set_retrieval_scores <- function(
   }
 
   compare <- create_comparison(
-    gold_standard, predicted,
+    predicted = predicted,
+    gold_standard = gold_standard,
     doc_groups = doc_groups,
     label_groups = label_groups,
     graded_relevance = graded_relevance,
@@ -326,8 +327,8 @@ compute_set_retrieval_scores <- function(
 #' @describeIn compute_set_retrieval_scores variant with internal usage of
 #'  dplyr rather than collapse library. Tends to be slower, but more stable
 compute_set_retrieval_scores_dplyr <- function( # nolint styler: off
-    gold_standard,
     predicted,
+    gold_standard,
     k = NULL,
     mode = "doc-avg",
     compute_bootstrap_ci = FALSE,
@@ -360,7 +361,8 @@ compute_set_retrieval_scores_dplyr <- function( # nolint styler: off
   }
 
   compare <- create_comparison(
-    gold_standard, predicted,
+    predicted = predicted,
+    gold_standard = gold_standard,
     doc_groups = doc_groups,
     label_groups = label_groups,
     graded_relevance = graded_relevance,

--- a/R/create_comparison.r
+++ b/R/create_comparison.r
@@ -32,9 +32,9 @@
 #'   "C", "f"
 #' )
 #'
-#' casimir::create_comparison(gold, pred)
+#' casimir::create_comparison(pred, gold)
 create_comparison <- function(
-    gold_standard, predicted,
+    predicted, gold_standard,
     doc_groups = NULL, label_groups = NULL,
     graded_relevance = FALSE,
     propensity_scored = FALSE,

--- a/man/compute_pr_auc.Rd
+++ b/man/compute_pr_auc.Rd
@@ -11,8 +11,8 @@ compute_pr_auc performs a two dimensional optimisation over thresholds and
 limits applying both threshold-based cutoff as well as rank-based cutoff.}
 \usage{
 compute_pr_auc(
-  gold_standard,
   predicted,
+  gold_standard,
   doc_groups = NULL,
   label_groups = NULL,
   mode = "doc-avg",
@@ -35,11 +35,11 @@ compute_pr_auc(
 )
 }
 \arguments{
-\item{gold_standard}{expects \code{data.frame} with cols
-\emph{"label_id", "doc_id"}}
-
 \item{predicted}{multi-label prediction results. expects \code{data.frame}
 with cols \emph{"label_id", "doc_id", "score"}}
+
+\item{gold_standard}{expects \code{data.frame} with cols
+\emph{"label_id", "doc_id"}}
 
 \item{doc_groups}{two-column \code{data.frame} with col \emph{"doc_id"}
 and a second column that defines groups of labels to stratify results by.
@@ -163,7 +163,7 @@ pred <- tibble::tribble(
   "C", "e", 0.2, 1
 )
 
-auc <- compute_pr_auc(gold, pred, mode = "doc-avg")
+auc <- compute_pr_auc(pred, gold, mode = "doc-avg")
 }
 \seealso{
 compute_set_retrieval_scores compute_pr_auc_from_curve

--- a/man/compute_pr_curve.Rd
+++ b/man/compute_pr_curve.Rd
@@ -5,8 +5,8 @@
 \title{compute precision-recall-curve for a given step size and limit_range}
 \usage{
 compute_pr_curve(
-  gold_standard,
   predicted,
+  gold_standard,
   doc_groups = NULL,
   label_groups = NULL,
   mode = "doc-avg",
@@ -26,11 +26,11 @@ compute_pr_curve(
 )
 }
 \arguments{
-\item{gold_standard}{expects \code{data.frame} with cols
-\emph{"label_id", "doc_id"}}
-
 \item{predicted}{multi-label prediction results. expects \code{data.frame}
 with cols \emph{"label_id", "doc_id", "score"}}
+
+\item{gold_standard}{expects \code{data.frame} with cols
+\emph{"label_id", "doc_id"}}
 
 \item{doc_groups}{two-column \code{data.frame} with col \emph{"doc_id"}
 and a second column that defines groups of labels to stratify results by.
@@ -153,8 +153,8 @@ pred <- tibble::tribble(
 )
 
 pr_curve <- compute_pr_curve(
-  gold,
   pred,
+  gold,
   mode = "doc-avg",
   optimize_cutoff = TRUE
 )

--- a/man/compute_ranked_retrieval_scores.Rd
+++ b/man/compute_ranked_retrieval_scores.Rd
@@ -5,19 +5,19 @@
 \title{Compute ranked retrieval scores}
 \usage{
 compute_ranked_retrieval_scores(
-  gold_standard,
   predicted,
+  gold_standard,
   doc_groups = NULL,
   drop_empty_groups = options::opt("drop_empty_groups"),
   progress = options::opt("progress")
 )
 }
 \arguments{
-\item{gold_standard}{expects \code{data.frame} with cols
-\emph{"label_id", "doc_id"}}
-
 \item{predicted}{multi-label prediction results. expects \code{data.frame}
 with cols \emph{"label_id", "doc_id", "score"}}
+
+\item{gold_standard}{expects \code{data.frame} with cols
+\emph{"label_id", "doc_id"}}
 
 \item{doc_groups}{two-column \code{data.frame} with col \emph{"doc_id"}
 and a second column that defines groups of labels to stratify results by.
@@ -73,8 +73,8 @@ pred <- tibble::tribble(
 )
 
 results <- compute_ranked_retrieval_scores(
-  gold,
-  pred
+  pred,
+  gold
 )
 
 }

--- a/man/compute_set_retrieval_scores.Rd
+++ b/man/compute_set_retrieval_scores.Rd
@@ -6,8 +6,8 @@
 \title{Compute multi label metrics for subject indexing results}
 \usage{
 compute_set_retrieval_scores(
-  gold_standard,
   predicted,
+  gold_standard,
   k = NULL,
   mode = "doc-avg",
   compute_bootstrap_ci = FALSE,
@@ -28,8 +28,8 @@ compute_set_retrieval_scores(
 )
 
 compute_set_retrieval_scores_dplyr(
-  gold_standard,
   predicted,
+  gold_standard,
   k = NULL,
   mode = "doc-avg",
   compute_bootstrap_ci = FALSE,
@@ -48,11 +48,11 @@ compute_set_retrieval_scores_dplyr(
 )
 }
 \arguments{
-\item{gold_standard}{expects \code{data.frame} with cols
-\emph{"label_id", "doc_id"}}
-
 \item{predicted}{multi-label prediction results. expects \code{data.frame}
 with cols \emph{"label_id", "doc_id"}}
+
+\item{gold_standard}{expects \code{data.frame} with cols
+\emph{"label_id", "doc_id"}}
 
 \item{k}{integer limit on number of predictions per document to consider.
 Only works when column \emph{"score"} is present in predicted}
@@ -181,7 +181,7 @@ pred <- tibble::tribble(
 plan(sequential) # or whatever resources you have
 
 a <- compute_set_retrieval_scores(
-  gold, pred,
+  pred, gold,
   mode = "doc-avg",
   compute_bootstrap_ci = TRUE,
   n_bt = 100L
@@ -205,7 +205,7 @@ pred_w_relevance <- tibble::tribble(
 )
 
 b <- compute_set_retrieval_scores(
-  gold, pred_w_relevance,
+  pred_w_relevance, gold,
   mode = "doc-avg",
   graded_relevance = TRUE
 )

--- a/man/create_comparison.Rd
+++ b/man/create_comparison.Rd
@@ -5,8 +5,8 @@
 \title{Join gold standard and predicted results in one table}
 \usage{
 create_comparison(
-  gold_standard,
   predicted,
+  gold_standard,
   doc_groups = NULL,
   label_groups = NULL,
   graded_relevance = FALSE,
@@ -16,11 +16,11 @@ create_comparison(
 )
 }
 \arguments{
-\item{gold_standard}{expects \code{data.frame} with cols
-\emph{"label_id", "doc_id"}}
-
 \item{predicted}{multi-label prediction results. expects \code{data.frame}
 with cols \emph{"label_id", "doc_id"}}
+
+\item{gold_standard}{expects \code{data.frame} with cols
+\emph{"label_id", "doc_id"}}
 
 \item{doc_groups}{two-column \code{data.frame} with col \emph{"doc_id"}
 and a second column that defines groups of labels to stratify results by.
@@ -87,5 +87,5 @@ pred <- tibble::tribble(
   "C", "f"
 )
 
-casimir::create_comparison(gold, pred)
+casimir::create_comparison(pred, gold)
 }

--- a/tests/testthat/test-apply_threshold.r
+++ b/tests/testthat/test-apply_threshold.r
@@ -26,7 +26,7 @@ test_that("threshold application works", {
     "C", "e", 0.2, 2L
   )
 
-  base_compare <- casimir:::create_comparison(gold, pred)
+  base_compare <- casimir:::create_comparison(pred, gold)
   # apply zero as threshold should not change anything
   res_0 <- casimir:::apply_threshold(threshold = 0, base_compare = base_compare)
   expect_equal(res_0, base_compare)
@@ -82,7 +82,7 @@ test_that("threshold application works", {
     "C", "c", 0.2,
     "C", "e", 0.2
   )
-  compare2 <- casimir:::create_comparison(gold, pred2)
+  compare2 <- casimir:::create_comparison(pred2, gold)
 
   expect_error(
     apply_threshold(base_compare = compare2, limit = 0.5),

--- a/tests/testthat/test-compute_intermediate_results.r
+++ b/tests/testthat/test-compute_intermediate_results.r
@@ -23,7 +23,7 @@ test_that("compute_intermediate_results checks out", {
     "C", "f"
   )
 
-  compare_gold_vs_pred <- casimir:::create_comparison(gold, pred_scenario1)
+  compare_gold_vs_pred <- casimir:::create_comparison(pred_scenario1, gold)
   res_per_doc_dplyr <- casimir:::compute_intermediate_results_dplyr(
     compare_gold_vs_pred,
     grouping_var = rlang::syms(c("doc_id"))
@@ -134,8 +134,8 @@ test_that("grouping vars with dots are rejected", {
     "C", "f"
   )
 
-  cmp_w_dots <- create_comparison(gold, pred, doc_groups = doc_groups_w_dots)
-  cmp_no_dots <- create_comparison(gold, pred, doc_groups = doc_groups_no_dots)
+  cmp_w_dots <- create_comparison(pred, gold, doc_groups = doc_groups_w_dots)
+  cmp_no_dots <- create_comparison(pred, gold, doc_groups = doc_groups_no_dots)
   res_w_dots <- compute_intermediate_results(
     cmp_w_dots,
     grouping_var = c("doc_id", "hsg")
@@ -218,7 +218,7 @@ test_that("f1-score handles missings expectedly in intermediate stage", {
     "A", "c"
   )
 
-  comp <- create_comparison(gold, pred)
+  comp <- create_comparison(pred, gold)
 
   expected_res <- tibble::tribble(
     ~label_id, ~n_gold, ~n_suggested, ~tp, ~fp, ~fn, ~delta_relevance, ~rprec_deno, ~prec, ~rprec, ~rec, ~f1, # nolint
@@ -283,8 +283,8 @@ test_that("propensity scored rprecision is correct on intermediate level", {
   )
 
   comp <- create_comparison(
-    gold = gold,
-    pred = pred
+    pred = pred,
+    gold = gold
   )
 
   ps_scores <- compute_propensity_scores(label_distribution)
@@ -411,7 +411,7 @@ test_that(
     )
 
     comp <- create_comparison(
-      gold, pred_w_relevance,
+      pred_w_relevance, gold,
       graded_relevance = TRUE
     )
 

--- a/tests/testthat/test-compute_pr_auc.r
+++ b/tests/testthat/test-compute_pr_auc.r
@@ -59,7 +59,7 @@ test_that("ci for pr_auc work", {
     )
   )
 
-  pr_auc <- compute_pr_auc(gold, pred,
+  pr_auc <- compute_pr_auc(pred, gold,
     steps = 15,
     compute_bootstrap_ci = TRUE,
     seed = 3426,
@@ -155,7 +155,7 @@ test_that("Zero AUC for singleton-curve in empty label_strata", {
     "i", "location"
   )
 
-  res <- compute_pr_auc(gold, pred, label_groups = label_groups, steps = 10)
+  res <- compute_pr_auc(pred, gold, label_groups = label_groups, steps = 10)
 
   edge_cases_expected <- tibble::tribble(
     ~gnd_entity, ~pr_auc,

--- a/tests/testthat/test-compute_pr_curve.r
+++ b/tests/testthat/test-compute_pr_curve.r
@@ -28,7 +28,7 @@ test_that("pr curve computation works", {
     "C", "e", 0.2
   )
 
-  comp <- create_comparison(gold, pred)
+  comp <- create_comparison(pred, gold)
 
   thresholds <- unique(quantile(pred$score, probs = seq(0, 1, 0.1), type = 1))
   # Here is code to "manually" compute the pr curves
@@ -59,7 +59,7 @@ test_that("pr curve computation works", {
       .f = ~ dplyr::arrange(
         expect_silent(
           compute_pr_curve(
-            gold, pred,
+            pred, gold,
             mode = .x, thresholds = thresholds
           )$plot_data
         ),
@@ -132,8 +132,8 @@ test_that("pr curve computation works", {
     .f = function(.mode, .steps, .optimize) {
       expect_silent(
         object = compute_pr_curve(
-          gold_standard = gold,
           predicted = pred,
+          gold_standard = gold,
           mode = .mode,
           steps = .steps,
           optimize_cutoff = .optimize
@@ -187,7 +187,7 @@ test_that("grouped pr-auc computation works with doc_groups", {
   ))
   # test whether parallel computation yields the same as sequential computation
   pr_curve_by_hsg_parallel <- compute_pr_curve(
-    gold, pred,
+    pred, gold,
     doc_groups = doc_groups,
     thresholds = thresholds
   )$plot_data |>
@@ -204,8 +204,8 @@ test_that("grouped pr-auc computation works with doc_groups", {
         )
 
         compute_pr_curve(
-          gold_standard = gold_1hsg,
           predicted = pred_1hsg,
+          gold_standard = gold_1hsg,
           thresholds = thresholds
         )$plot_data
       },
@@ -275,7 +275,7 @@ test_that("grouped pr-auc computation works with label_strata", {
     pred$score,
     probs = seq(0, 1, 1 / steps), type = 1
   ))
-  pr_curve_by_lbl_grp <- compute_pr_curve(gold, pred,
+  pr_curve_by_lbl_grp <- compute_pr_curve(pred, gold,
     label_groups = label_dict,
     thresholds = seq(0, 1, 1 / steps)
   )
@@ -310,8 +310,8 @@ test_that("optimal cutoff works", {
   # purrr would cause an attach massage otherwise
 
   pr_curve <- expect_silent(compute_pr_curve(
-    gold_standard = dnb_gold_standard,
     predicted = dnb_test_predictions,
+    gold_standard = dnb_gold_standard,
     limit_range = 1:5,
     steps = 15,
     optimize_cutoff = TRUE
@@ -340,8 +340,8 @@ test_that("grouped cutoff works", {
   hsg_mapping <- readRDS(test_path("testdata/random_hsg_mapping.rds"))
 
   res <- compute_pr_curve(
-    gold_standard = dnb_gold_standard,
     predicted = dnb_test_predictions,
+    gold_standard = dnb_gold_standard,
     doc_groups = hsg_mapping,
     limit_range = c(1:5),
     steps = 10,
@@ -420,7 +420,7 @@ test_that("Empty Recall in label strata gives singleton-curve", {
   )
 
   res <- compute_pr_curve(
-    gold, pred,
+    pred, gold,
     label_groups = label_groups, steps = 10, mode = "micro"
   )
 

--- a/tests/testthat/test-compute_ranked_retrieval_scores.r
+++ b/tests/testthat/test-compute_ranked_retrieval_scores.r
@@ -24,7 +24,7 @@ test_that("compute_ranked_retrieval_scores works", {
   )
 
   expect_silent(
-    observed <- compute_ranked_retrieval_scores(gold, pred)
+    observed <- compute_ranked_retrieval_scores(pred, gold)
   )
 
   expected <- tibble::tribble(
@@ -82,8 +82,8 @@ test_that("grouped ranked retrieval works", {
     dplyr::mutate(score = runif(dplyr::n()))
 
   observed <- compute_ranked_retrieval_scores(
-    gold,
     pred,
+    gold,
     doc_groups = doc_groups,
     drop_empty_groups = FALSE
   )
@@ -93,7 +93,7 @@ test_that("grouped ranked retrieval works", {
     nrow(dplyr::filter(observed, hsg == "006")), 3L
   )
 
-  doc_wise_results <- create_comparison(gold, pred, doc_groups = doc_groups) |>
+  doc_wise_results <- create_comparison(pred, gold, doc_groups = doc_groups) |>
     dplyr::group_by(doc_id, hsg) |>
     dplyr::do(
       ndcg = ndcg_score(.), # according to Reference implementation

--- a/tests/testthat/test-compute_set_retrieval_scores.r
+++ b/tests/testthat/test-compute_set_retrieval_scores.r
@@ -67,7 +67,7 @@ test_that("compute_set_retrieval_scores works", {
     .x = expected_results,
     .f = ~ expect_equal(
       object = compute_set_retrieval_scores_dplyr(
-        gold, pred,
+        pred, gold,
         mode = .y,
         ignore_inconsistencies = TRUE
       ),
@@ -79,7 +79,7 @@ test_that("compute_set_retrieval_scores works", {
     .x = expected_results,
     .f = ~ expect_equal(
       object = compute_set_retrieval_scores(
-        gold, pred,
+        pred, gold,
         mode = .y,
         ignore_inconsistencies = TRUE
       ),
@@ -111,8 +111,8 @@ test_that("compute_set_retrieval_scores works", {
                   .cost_fp_constant) {
       expect_silent(
         object = compute_set_retrieval_scores_dplyr(
-          gold,
           pred,
+          gold,
           mode = .mode,
           seed = 10,
           graded_relevance = .graded_relevance,
@@ -134,8 +134,8 @@ test_that("compute_set_retrieval_scores works", {
                   .propensity_scored, .cost_fp_constant) {
       expect_silent(
         object = compute_set_retrieval_scores(
-          gold,
           pred,
+          gold,
           mode = .mode,
           seed = 10,
           graded_relevance = .graded_relevance,
@@ -181,11 +181,11 @@ test_that("f1 scores handles missings expectedly for micro-avg", {
   )
 
   expect_warning(
-    res_collapse <- compute_set_retrieval_scores(gold, pred, mode = "micro"),
+    res_collapse <- compute_set_retrieval_scores(pred, gold, mode = "micro"),
     "gold standard data contains documents that are not in predicted set"
   )
   expect_warning(
-    res_dplyr <- compute_set_retrieval_scores_dplyr(gold, pred, mode = "micro"),
+    res_dplyr <- compute_set_retrieval_scores_dplyr(pred, gold, mode = "micro"),
     "gold standard data contains documents that are not in predicted set"
   )
 
@@ -202,8 +202,8 @@ test_that("graded relevance metrics are computed correctly", {
   # reference implementation adapted from markus' code
   reference_graded_relevance <- function(gold_standard, predicted) {
     comp <- create_comparison(
-      gold_standard,
       dplyr::filter(predicted, !is.na(relevance)),
+      gold_standard,
       ignore_inconsistencies = TRUE
     ) |>
       # remove artificially generated relevance = 0 column
@@ -272,8 +272,8 @@ test_that("graded relevance metrics are computed correctly", {
 
   # GP and GR should be larger then binary precision and recall
   binary_relevance <- compute_set_retrieval_scores(
-    gold,
     pred_no_relevance,
+    gold,
     graded_relevance = FALSE,
     mode = "doc-avg"
   ) |>
@@ -281,8 +281,8 @@ test_that("graded relevance metrics are computed correctly", {
     dplyr::rename_with(~ paste0("binary_", .x))
 
   graded_relevance <- compute_set_retrieval_scores(
-    gold,
     pred_w_relevance,
+    gold,
     graded_relevance = TRUE,
     mode = "doc-avg"
   ) |>
@@ -304,8 +304,8 @@ test_that("graded relevance metrics are computed correctly", {
   reference_res <- reference_graded_relevance(gold, pred_w_relevance)
 
   casimir_res <- compute_set_retrieval_scores(
-    gold,
     pred_w_relevance,
+    gold,
     graded_relevance = TRUE,
     rename_graded_metrics = TRUE,
     mode = "doc-avg"
@@ -340,8 +340,8 @@ test_that("graded relevance metrics are computed correctly", {
 
   expect_warning(
     compute_set_retrieval_scores(
-      gold,
       inconsistent_pred_w_relevance,
+      gold,
       graded_relevance = TRUE,
       mode = "doc-avg"
     ),
@@ -365,8 +365,8 @@ test_that("graded relevance metrics are computed correctly", {
 
   expect_warning(
     compute_set_retrieval_scores(
-      gold,
       pred_w_missing_relevance,
+      gold,
       graded_relevance = TRUE,
       mode = "doc-avg"
     ),
@@ -387,8 +387,8 @@ test_that("graded relevance metrics are computed correctly", {
 
   expect_warning(
     compute_set_retrieval_scores(
-      gold,
       pred_w_false_gold,
+      gold,
       graded_relevance = TRUE,
       mode = "doc-avg"
     ),
@@ -440,8 +440,8 @@ test_that("propensity scores works", {
 
   expect_silent(
     compute_set_retrieval_scores(
-      gold = gold,
       pred = pred,
+      gold = gold,
       mode = "doc-avg",
       propensity_scored = TRUE,
       label_distribution = label_distribution,
@@ -453,8 +453,8 @@ test_that("propensity scores works", {
   # check that errors occur if a label has no match in label_distribution
   expect_error(
     compute_set_retrieval_scores(
-      gold = gold,
       pred = pred,
+      gold = gold,
       mode = "doc-avg",
       propensity_scored = TRUE,
       label_distribution = dplyr::filter(label_distribution, label_id != "a"),
@@ -477,8 +477,8 @@ test_that("propensity scores works", {
 
   expect_error(
     compute_set_retrieval_scores(
-      gold = gold,
       pred = pred,
+      gold = gold,
       mode = "doc-avg",
       propensity_scored = TRUE,
       label_distribution = faulty_label_distribution,
@@ -518,7 +518,7 @@ test_that("propensity scores works", {
     .x = expected_results,
     .f = ~ expect_equal(
       object = compute_set_retrieval_scores(
-        gold, pred,
+        pred, gold,
         mode = .y, propensity_scored = TRUE,
         label_distribution = label_distribution,
         cost_fp_constant = "mean"
@@ -532,7 +532,7 @@ test_that("propensity scores works", {
     .x = expected_results,
     .f = ~ expect_equal(
       object = compute_set_retrieval_scores_dplyr(
-        gold, pred,
+        pred, gold,
         mode = .y, propensity_scored = TRUE,
         label_distribution = label_distribution,
         cost_fp_constant = "mean"
@@ -594,8 +594,8 @@ test_that(paste(
   )
 
   compare <- create_comparison(
-    gold_standard = dnb_gold_standard,
     predicted = dnb_test_predictions,
+    gold_standard = dnb_gold_standard,
     propensity_scored = TRUE,
     label_distribution = dnb_label_distribution
   )
@@ -643,15 +643,15 @@ test_that(paste(
   )
 
   res_wrapped <- compute_set_retrieval_scores(
-    gold,
     pred_w_relevance,
+    gold,
     graded_relevance = TRUE,
     mode = "doc-avg"
   )
 
   comp <- create_comparison(
-    gold_standard = gold,
     predicted = pred_w_relevance,
+    gold_standard = gold,
     graded_relevance = TRUE
   )
 
@@ -673,11 +673,11 @@ test_that("Limit k is set correctly", {
   pred_at_5 <-  dplyr::filter(df, rank <= 5)
 
   expected_res <- compute_set_retrieval_scores(
-    dnb_gold_standard, pred_at_5
+    pred_at_5, dnb_gold_standard
   )
 
   observed_res <- compute_set_retrieval_scores(
-    dnb_gold_standard, df, k = 5
+    df, dnb_gold_standard, k = 5
   )
 
   expect_equal(
@@ -686,7 +686,7 @@ test_that("Limit k is set correctly", {
   )
 
   observed_res_dplyr <- compute_set_retrieval_scores_dplyr(
-    dnb_gold_standard, df, k = 5
+    df, dnb_gold_standard, k = 5
   )
 
   expect_equal(observed_res_dplyr, observed_res)

--- a/tests/testthat/test-create_comparison.r
+++ b/tests/testthat/test-create_comparison.r
@@ -24,7 +24,7 @@ test_that("create_comparison produces no nonesens", {
   )
 
   # scenario runs throughs undisturbed
-  expect_silent(casimir:::create_comparison(gold, pred_scenario1))
+  expect_silent(casimir:::create_comparison(pred_scenario1, gold))
 
 
   pred_scenario2 <- tibble::tribble(
@@ -37,7 +37,7 @@ test_that("create_comparison produces no nonesens", {
     "D", "f"
   )
 
-  expect_error(casimir:::create_comparison(gold, pred_scenario2),
+  expect_error(casimir:::create_comparison(pred_scenario2, gold),
     regexp = "nrow\\(predicted_wo_gold\\) == 0 is not TRUE"
   )
 
@@ -51,7 +51,7 @@ test_that("create_comparison produces no nonesens", {
   )
 
   expect_warning(
-    create_comparison(gold, pred_scenario3),
+    create_comparison(pred_scenario3, gold),
     regexp = "gold standard data contains documents that are not in predicted set" # nolint
   )
 
@@ -59,7 +59,7 @@ test_that("create_comparison produces no nonesens", {
   withr::with_options(
     list(casimir.ignore_inconsistencies = TRUE),
     {
-      expect_silent(create_comparison(gold, pred_scenario3))
+      expect_silent(create_comparison(pred_scenario3, gold))
     }
   )
 })

--- a/tests/testthat/test-empty_factor_levels.r
+++ b/tests/testthat/test-empty_factor_levels.r
@@ -42,7 +42,7 @@ test_that("empty factor levels can be handled", {
   ) |>
     dplyr::mutate(gnd_entity = as.factor(gnd_entity))
   withr::local_options(list(casimir.drop_empty_groups = FALSE))
-  comp <- create_comparison(gold, pred, label_groups = label_groups)
+  comp <- create_comparison(pred, gold, label_groups = label_groups)
   intermed <- compute_intermediate_results(comp, c("label_id", "gnd_entity"))
 
   n <- nrow(dplyr::filter(intermed$results_table, gnd_entity == "empty_group"))
@@ -57,7 +57,7 @@ test_that("empty factor levels can be handled", {
     4L
   )
   withr::local_options(list(casimir.drop_empty_groups = TRUE))
-  comp <- create_comparison(gold, pred, label_groups = label_groups)
+  comp <- create_comparison(pred, gold, label_groups = label_groups)
   intermed <- compute_intermediate_results(comp, c("label_id", "gnd_entity"))
 
   n <- nrow(dplyr::filter(intermed$results_table, gnd_entity == "empty_group"))

--- a/tests/testthat/test-grouped_set_retrieval.r
+++ b/tests/testthat/test-grouped_set_retrieval.r
@@ -47,11 +47,11 @@ test_that("grouping (doc-strata) of set retrieval computation works", {
 
   # expect no error when adding strata
   expect_silent(
-    casimir:::create_comparison(gold, pred, doc_groups = doc_groups)
+    casimir:::create_comparison(pred, gold, doc_groups = doc_groups)
   )
   # expect NA in hsg-column of compare, when no doc_strata are defined
   compare_wo_explicit_strata <- casimir:::create_comparison(
-    gold, pred,
+    pred, gold,
     doc_groups = NULL
   )
   expect_equal(
@@ -64,20 +64,20 @@ test_that("grouping (doc-strata) of set retrieval computation works", {
   gold_002 <- dplyr::select(gold_002, -hsg)
 
   res <- compute_set_retrieval_scores_dplyr(
-    gold, pred,
+    pred, gold,
     mode = "doc-avg", doc_groups = doc_groups
   )
   res_collapse <- compute_set_retrieval_scores(
-    gold, pred,
+    pred, gold,
     mode = "doc-avg", doc_groups = doc_groups
   )
 
   res_001 <- compute_set_retrieval_scores_dplyr(
-    gold_001, pred_001,
+    pred_001, gold_001,
     mode = "doc-avg"
   )
   res_002 <- compute_set_retrieval_scores_dplyr(
-    gold_002, pred_002,
+    pred_002, gold_002,
     mode = "doc-avg"
   )
 
@@ -97,7 +97,7 @@ test_that("grouping (doc-strata) of set retrieval computation works", {
   # if doc_strata is not a factor, it may loose instances during bootstrap
   expect_warning(
     object = compute_set_retrieval_scores_dplyr(
-      gold, pred,
+      pred, gold,
       mode = "doc-avg",
       doc_groups = doc_groups,
       compute_bootstrap_ci = TRUE,
@@ -108,8 +108,8 @@ test_that("grouping (doc-strata) of set retrieval computation works", {
 
   doc_groups_w_factor <- dplyr::mutate(doc_groups, hsg = as.factor(hsg))
   compare <- create_comparison(
-    gold_standard = gold,
     predicted = pred,
+    gold_standard = gold,
     doc_groups = doc_groups_w_factor
   )
   boot_res <- generate_replicate_results_dplyr(
@@ -136,8 +136,8 @@ test_that("grouping (doc-strata) of set retrieval computation works", {
     configuration$mode, configuration$compute_bootstrap_ci,
     .f = ~ expect_silent(
       object = compute_set_retrieval_scores_dplyr(
-        gold,
         pred,
+        gold,
         mode = .x,
         doc_groups = doc_groups_w_factor,
         compute_bootstrap_ci = .y,
@@ -150,8 +150,8 @@ test_that("grouping (doc-strata) of set retrieval computation works", {
     configuration$mode, configuration$compute_bootstrap_ci,
     .f = ~ expect_silent(
       object = compute_set_retrieval_scores(
-        gold,
         pred,
+        gold,
         mode = .x,
         doc_groups = doc_groups_w_factor,
         seed = 10,
@@ -240,7 +240,7 @@ test_that("grouping (label-groups) of set retrieval computation works", {
   # check intermediate results level
   ####################################################
   comparison_w_label_groups <- casimir:::create_comparison(
-    gold, pred,
+    pred, gold,
     label_groups = label_groups
   )
   interm_res_grpd_act <- dplyr::select(
@@ -326,7 +326,7 @@ test_that("grouping (label-groups) of set retrieval computation works", {
     .x = expected_res,
     .f = ~ expect_equal(
       object = compute_set_retrieval_scores_dplyr(
-        gold, pred,
+        pred, gold,
         mode = .y,
         label_groups = label_groups
       ),
@@ -337,7 +337,7 @@ test_that("grouping (label-groups) of set retrieval computation works", {
     .x = purrr::map(expected_res, .f = dplyr::ungroup),
     .f = ~ expect_equal(
       object = compute_set_retrieval_scores(
-        gold, pred,
+        pred, gold,
         mode = .y,
         label_groups = label_groups
       ),
@@ -356,7 +356,7 @@ test_that("grouping (label-groups) of set retrieval computation works", {
   # if label_strata is not a factor, it may loose instances during bootstrap
   expect_warning(
     object = compute_set_retrieval_scores_dplyr(
-      gold, pred,
+      pred, gold,
       mode = "doc-avg",
       label_groups = label_groups,
       compute_bootstrap_ci = TRUE, n_bt = 10L
@@ -368,7 +368,7 @@ test_that("grouping (label-groups) of set retrieval computation works", {
     label_groups,
     gnd_entity = as.factor(gnd_entity)
   )
-  compare <- create_comparison(gold, pred, label_groups = label_groups_w_factor)
+  compare <- create_comparison(pred, gold, label_groups = label_groups_w_factor)
   boot_res <- generate_replicate_results_dplyr(
     base_compare = compare,
     n_bt = 10L,
@@ -395,8 +395,8 @@ test_that("grouping (label-groups) of set retrieval computation works", {
     .f = function(.mode, .compute_bootstrap_ci, .progress) { # nolint
       expect_silent(
         object = compute_set_retrieval_scores_dplyr(
-          gold,
           pred,
+          gold,
           mode = .mode,
           label_groups = label_groups_w_factor,
           compute_bootstrap_ci = .compute_bootstrap_ci,
@@ -411,8 +411,8 @@ test_that("grouping (label-groups) of set retrieval computation works", {
     .f = function(.mode, .compute_bootstrap_ci, .progress) { # nolint
       expect_silent(
         object = compute_set_retrieval_scores(
-          gold,
           pred,
+          gold,
           mode = .mode,
           label_groups = label_groups_w_factor,
           compute_bootstrap_ci = .compute_bootstrap_ci,

--- a/tests/testthat/test-summarise_intermediate_results.r
+++ b/tests/testthat/test-summarise_intermediate_results.r
@@ -227,7 +227,7 @@ test_that("Summarise works with weighted mean", {
     # cause an error
   )
 
-  comp <- create_comparison(gold, pred)
+  comp <- create_comparison(pred, gold)
 
   label_wise_res_no_weight <- compute_intermediate_results(
     gold_vs_pred = comp,
@@ -286,7 +286,7 @@ test_that("summarise can replace na precison", {
     "A", "c"
   )
 
-  comp <- create_comparison(gold, pred)
+  comp <- create_comparison(pred, gold)
 
   interm <- compute_intermediate_results(comp, "label_id")
 


### PR DESCRIPTION
Switch order of predicted and gold_standard to allow save iteration on multiple prediction sets with lapply and co.